### PR TITLE
Add anticipation2 for second event

### DIFF
--- a/R/double_did.R
+++ b/R/double_did.R
@@ -131,9 +131,9 @@ get_es_ggt_weight <- function(ggt, group_time, aux, p){
     
   } else if(g1 < g2) { #imputation = treat-pre + (control-post - control-pre)
     
-    base_period <- g2 - 1
+    base_period <- g2 - 1 - p$anticipation2
     if(base_period == t){return(NULL)}
-    min_control_cohort <- ifelse(p$double_control_option == "never", Inf, max(t,base_period)+1)
+    min_control_cohort <- ifelse(p$double_control_option == "never", Inf, max(t,base_period)+p$anticipation2+1)
     
     #get the cohorts
     tb <- group_time[,G == gg & time == base_period]
@@ -155,9 +155,9 @@ get_es_ggt_weight <- function(ggt, group_time, aux, p){
     
   } else if (g1 > g2) { #double did = (treat-post - treat-base) - (control-post - control-pre)
     
-    base_period <- g1 - 1
+    base_period <- g1 - 1 - p$anticipation
     if(base_period == t){return(NULL)}
-    min_control_cohort <- ifelse(p$double_control_option == "never", Inf, max(t,base_period)+1)
+    min_control_cohort <- ifelse(p$double_control_option == "never", Inf, max(t,base_period)+p$anticipation+1)
     
     #get the cohorts
     tp <- group_time[,.I == ggt]

--- a/R/fastdid.R
+++ b/R/fastdid.R
@@ -22,8 +22,9 @@
 #' @param varycovariatesvar character vector, names of time-varying covariate variables.
 #' @param copy logical, whether to copy the dataset. 
 #' @param validate logical, whether to validate the dataset. 
-#' @param anticipation number, periods with anticipation. 
-#' @param exper list, arguments for experimental features. 
+#' @param anticipation number, periods with anticipation.
+#' @param anticipation2 number, periods with anticipation for the second event.
+#' @param exper list, arguments for experimental features.
 #' @param base_period character, type of base period in pre-preiods, options are "universal", or "varying".
 #' @param full logical, whether to return the full result (influence function, call, weighting scheme, etc,.). 
 #' @param parallel logical, whether to use parallization on unix system. 
@@ -64,8 +65,8 @@ fastdid <- function(data,
                     control_type = "ipw", allow_unbalance_panel = FALSE, boot=FALSE, biters = 1000, cband = FALSE, alpha = 0.05,
                     weightvar=NA,clustervar=NA, covariatesvar = NA, varycovariatesvar = NA, 
                     copy = TRUE, validate = TRUE,
-                    anticipation = 0,  base_period = "universal",
-                    exper = NULL, full = FALSE, parallel = FALSE, 
+                   anticipation = 0, anticipation2 = 0, base_period = "universal",
+                   exper = NULL, full = FALSE, parallel = FALSE,
                     cohortvar2 = NA, event_specific = TRUE, double_control_option="both"){
   
   # preprocess --------------------------------------------------------

--- a/R/global.R
+++ b/R/global.R
@@ -9,7 +9,7 @@ utils::globalVariables(c('.','agg_weight','att','att_cont','att_treat','attgt','
                          'V1','att_cont_post','att_cont_pre','att_treat_post','att_treat_pre','inpost','inpre','max_et','min_et','new_unit','or_delta','or_delta_post','or_delta_pre','targeted','used',
                          "timevar", "cohortvar", "unitvar", "outcomevar", "control_option", "result_type", "balanced_event_time", "control_type",
                          "allow_unbalance_panel", "boot", "biters", "weightvar", "clustervar", "covariatesvar", "varycovariatesvar", "filtervar",
-                         "copy", "validate", "max_control_cohort_diff", "anticipation", "min_control_cohort_diff", "base_period", "post", "att_ciub", "att_cilb", "cband", "alpha",
+                         "copy", "validate", "max_control_cohort_diff", "anticipation", "anticipation2", "min_control_cohort_diff", "base_period", "post", "att_ciub", "att_cilb", "cband", "alpha",
                          "G2", "G1", "mg", "cohort1", "cohort2", "event_time_1", "event_time_2",
                          "D2", "attgt2", "event", "atu2", "y01", "y10", "y11", "tau2", "parallel",
                          "tp", "cp", "tb", "cb", "no_na", "event_stagger", "double_control_option",

--- a/R/validate.R
+++ b/R/validate.R
@@ -25,7 +25,7 @@ validate_argument <- function(dt, p){
   check_set_arg(control_type, "match", .choices = c("ipw", "reg", "dr"), .up = 1) 
   check_set_arg(base_period, "match", .choices = c("varying", "universal"), .up = 1)
   check_arg(copy, validate, boot, allow_unbalance_panel, cband, parallel, "scalar logical", .up = 1)
-  check_arg(anticipation, alpha, "scalar numeric", .up = 1)
+  check_arg(anticipation, anticipation2, alpha, "scalar numeric", .up = 1)
   
   if(!is.na(balanced_event_time)){
     if(result_type != "dynamic"){stop("balanced_event_time is only meaningful with result_type == 'dynamic'")}

--- a/man/fastdid.Rd
+++ b/man/fastdid.Rd
@@ -26,6 +26,7 @@ fastdid(
   copy = TRUE,
   validate = TRUE,
   anticipation = 0,
+  anticipation2 = 0,
   base_period = "universal",
   exper = NULL,
   full = FALSE,
@@ -77,6 +78,7 @@ fastdid(
 \item{validate}{logical, whether to validate the dataset.}
 
 \item{anticipation}{number, periods with anticipation.}
+\item{anticipation2}{number, periods with anticipation for the second event.}
 
 \item{base_period}{character, type of base period in pre-preiods, options are "universal", or "varying".}
 


### PR DESCRIPTION
## Summary
- support anticipation for second cohort by adding an `anticipation2` parameter
- document new argument and validate its usage
- adjust double DID base period calculations for anticipation

## Testing
- `tinytest::test_package("fastdid", testdir="inst/tinytest")` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3b4fb5f0832bb9b3cca3085c2e82