### PR TITLE
Improve robustness for unbalanced panels

### DIFF
--- a/R/estimate_did.R
+++ b/R/estimate_did.R
@@ -189,6 +189,11 @@ estimate_did_rc <- function(dt_did, covvars, p, cache){
   dt_did[, inpost := as.numeric(!is.na(post.y))]
   n_pre <- dt_did[, sum(!is.na(pre.y))]
   n_post <- dt_did[, sum(!is.na(post.y))]
+
+  if(n_pre == 0 || n_post == 0){
+    warning("No observations in pre or post period; skipping this 2x2 DiD")
+    return(list(att = NA, inf_func = rep(0, oldn), cache = NULL))
+  }
   
   sum_weight_pre <- dt_did[, sum(inpre*weights)]
   sum_weight_post <- dt_did[, sum(inpost*weights)]

--- a/R/estimate_gtatt.R
+++ b/R/estimate_gtatt.R
@@ -71,11 +71,21 @@ estimate_gtatt_outcome_gt <- function(gt, y, aux, p, caches){
   #the 2x2 dataset
   cohort_did <- data.table(did_setup, y[[t]], y[[base_period]], aux$weights)
   names(cohort_did) <- c("D", "post.y", "pre.y", "weights")
-  
+
+  # skip if no valid observation in either period when allowing for
+  # unbalanced panels
+  if(sum(!is.na(cohort_did$pre.y)) == 0 || sum(!is.na(cohort_did$post.y)) == 0){
+    return(NULL)
+  }
+
   # estimate --------------------
   result <- tryCatch(estimate_did(dt_did = cohort_did, covvars, p, caches[[gt_name]]),
-                     error = function(e){stop("2-by-2 DiD failed for internal group-time ",g , 
-                                              "-", t, ": ", e)})
+                     error = function(e){
+                       warning("Skipping group-time ", g, "-", t,
+                               ": ", e$message)
+                       return(NULL)
+                     })
+  if(is.null(result)){return(NULL)}
   return(list(gt = gt, result = result))
   
 }


### PR DESCRIPTION
## Summary
- avoid failures when pre or post period is missing
- skip invalid group-times instead of throwing errors

## Testing
- `Rscript -e "print('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3bc03e24832b8269d7b526d6b5e1